### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.0...v0.1.1) - 2025-02-15
+
+### Other
+
+- update dependencies
+- *(ci)* add GitHub Actions workflow for Release-plz automation
+- add categories and keywords to Cargo.toml
+- link to docs in readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- update dependencies
-- *(ci)* add GitHub Actions workflow for Release-plz automation
-- add categories and keywords to Cargo.toml
-- link to docs in readme
+- Update dependencies
+- Add categories and keywords to Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-pagecrypt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-pagecrypt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Wybxc/mdbook-pagecrypt"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-pagecrypt`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.0...v0.1.1) - 2025-02-15

### Other

- update dependencies
- *(ci)* add GitHub Actions workflow for Release-plz automation
- add categories and keywords to Cargo.toml
- link to docs in readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).