### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.2...v0.2.0) - 2026-03-09
+
+### Added
+
+- require password ([#4](https://github.com/Wybxc/mdbook-pagecrypt/pull/4))
+
+### Fixed
+
+- require password in PageCryptBuilder ([#6](https://github.com/Wybxc/mdbook-pagecrypt/pull/6))
+- encrypt toc.html ([#7](https://github.com/Wybxc/mdbook-pagecrypt/pull/7))
+
 ## [0.1.2](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.1...v0.1.2) - 2026-02-23
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- require password ([#4](https://github.com/Wybxc/mdbook-pagecrypt/pull/4))
+- Require `password` in `[output.pagecrypt]` configuration ([#4](https://github.com/Wybxc/mdbook-pagecrypt/pull/4))
+- Encrypt `toc.html` when present ([#7](https://github.com/Wybxc/mdbook-pagecrypt/pull/7))
+
+### Changed
+
+- Make `password` required in documentation and examples
 
 ### Fixed
 
-- require password in PageCryptBuilder ([#6](https://github.com/Wybxc/mdbook-pagecrypt/pull/6))
-- encrypt toc.html ([#7](https://github.com/Wybxc/mdbook-pagecrypt/pull/7))
+- Validate missing password in `PageCryptBuilder::build` ([#6](https://github.com/Wybxc/mdbook-pagecrypt/pull/6))
 
 ## [0.1.2](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.1...v0.1.2) - 2026-02-23
 
-### Other
+### Changed
 
-- Update dependencies
+- Upgrade to mdBook 0.5 API (`mdbook-html` and `mdbook-renderer`)
+- Update Rust dependencies and build-time minification configuration
+- Improve GitHub Actions workflows for pull request builds and release automation
+
+### Fixed
+
+- Remove unsupported `multilingual` option from docs configuration
 
 ## [0.1.1](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.0...v0.1.1) - 2025-02-15
 
-### Other
+### Added
 
-- Update dependencies
-- Add categories and keywords to Cargo.toml
+- Set up GitHub Pages publishing workflow
+- Add Release-plz automation workflow
+
+### Changed
+
+- Add package metadata (`description`, `categories`, `keywords`)
+- Add documentation link in README
+- Enable Rust cache in CI and update dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-pagecrypt"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-pagecrypt"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Wybxc/mdbook-pagecrypt"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-pagecrypt`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `mdbook-pagecrypt` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:MissingPassword in /tmp/.tmpDcK51C/mdbook-pagecrypt/src/lib.rs:18
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/Wybxc/mdbook-pagecrypt/compare/v0.1.2...v0.2.0) - 2026-03-09

### Added

- require password ([#4](https://github.com/Wybxc/mdbook-pagecrypt/pull/4))

### Fixed

- require password in PageCryptBuilder ([#6](https://github.com/Wybxc/mdbook-pagecrypt/pull/6))
- encrypt toc.html ([#7](https://github.com/Wybxc/mdbook-pagecrypt/pull/7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).